### PR TITLE
Corrige le problème de signal non émit par le node de type GridContainer

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -1,36 +1,57 @@
 extends Node
 
+# On précharge la scène contant le boutton.
+# Cet objet n'est pas créé, il est juste chargé en mémoire.
+# On peut voir cette scène comme tant un moule qui nous permet
+# de créer des objets de ce genre la en série.
+const BUTTON_SCENE = preload("res://Button.tscn")
+
+# En faisant un 'onready' on permet d'avoir ces 3 variables disponibles partout dans ce fichier
+# Ainsi il n'est pas nécessaire de refaire les mêmes actions plusieurs fois.
+onready var grp = get_node("ButtonGroup")
+onready var zoneButtonGroup = get_node("Panel/ButtonGroup")
+onready var zone = get_node("Panel/ButtonGroup/zone")
+
 func _ready():
-
-    var grp = get_node("ButtonGroup")
-    var zone = get_node("Panel/zone")
-
     var index = 0
     
     for itm in data.MAGASIN:
         var btn = Button.new()
-        var text = itm.nom
+        var text = '%s (%s)' % [itm.nom, itm.price]
+
+        # Il est préférable de définir le texte, la texture et les meta informations d'un node
+        # avant de l'ajouter a la scène. Car ajouter un node a une scène provoque un re-draw de ta scène
+        # et a chaque modification du node, on effectue un re-draw de la scène.
+        # Donc en faisant de cette manière, on économise 4 re-draw.
+        btn.set_text(text)
+        btn.set_meta('name', itm.nom)
+        btn.set_meta('price', itm.price)
+        btn.set_meta('id', index)
+
         grp.add_child(btn)
-        btn.set_text(itm.nom + ' (' + str(itm.price) + ')')
-        btn.set_meta('name' , itm.nom)
-        btn.set_meta('price' , itm.price)
-        btn.set_meta('id' , index )
+
         index += 1
         
-	
-    grp.connect('button_selected',self,'price_selected')
-    zone.connect('button_selected',self,'ele_selected')
+    
+    grp.connect('button_selected', self, 'price_selected')
+
+    # Le signal 'button_selected' est émis uniquement par un node de type 'ButtonGroup'
+    # J'ai donc ajouté un node 'ButtonGroup' entre le Panel et la zone, ainsi tu peux écouter le bon signal
+    zoneButtonGroup.connect('button_selected', self, 'ele_selected')
     
 
 func price_selected(button):
-	var scene = load("res://Button.tscn")
-	var meta = button.get_meta('name')
-	var ele = scene.instance()
-	ele.set_text(str(meta))
-	var parent = get_node("Panel/zone")
-	parent.add_child(ele)
-	  
-    #print(data.MAGASIN[meta].price)
+    var meta = button.get_meta('name')
+
+    # Depuis l'objet chargé en mémoire on crée un copie de cet objet
+    # qui maintenant peut être ajouté a notre scène.
+    var ele = BUTTON_SCENE.instance()
+
+    ele.set_text(str(meta))
+
+    zone.add_child(ele)
 
 func ele_selected(button):
-	print('jesuisla')
+    var name = button.get_text()
+
+    print('name: %s' % [name])

--- a/Main.tscn
+++ b/Main.tscn
@@ -29,7 +29,7 @@ margin/top = 80.0
 margin/right = 790.0
 margin/bottom = 380.0
 
-[node name="zone" type="GridContainer" parent="Panel"]
+[node name="ButtonGroup" type="ButtonGroup" parent="Panel"]
 
 focus/ignore_mouse = false
 focus/stop_mouse = false
@@ -37,8 +37,20 @@ size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
 margin/top = 0.0
-margin/right = 300.0
-margin/bottom = 300.0
+margin/right = 40.0
+margin/bottom = 40.0
+alignment = 0
+
+[node name="zone" type="GridContainer" parent="Panel/ButtonGroup"]
+
+focus/ignore_mouse = false
+focus/stop_mouse = false
+size_flags/horizontal = 2
+size_flags/vertical = 2
+margin/left = 0.0
+margin/top = 0.0
+margin/right = 40.0
+margin/bottom = 0.0
 columns = 3
 
 

--- a/Script/data.gd
+++ b/Script/data.gd
@@ -1,8 +1,8 @@
 extends Node
 
 const MAGASIN = [
-{"nom" : "shop", "price" : 150},
-{"nom" : "ferme", "price" : 400},
-{"nom" : "usine", "price" : 800},
-{"nom" : "cinema", "price" : 1200}
-];
+  {"nom" : "shop", "price" : 150},
+  {"nom" : "ferme", "price" : 400},
+  {"nom" : "usine", "price" : 800},
+  {"nom" : "cinema", "price" : 1200}
+]


### PR DESCRIPTION
J'aime bien l'approche que tu as pour ce prototype, et j'avoue que c'est élégant.

Un node de type GridContainer n'émet pas ou peu d'évènement (https://devdocs.io/godot~2.1/classes/class_gridcontainer).

Il y a une façon très simple de vérifier les signaux émis par un node, directement dans l'interface de Godot. Voici la capture d'écran qui te l'explique:


![godot engine - proto - main tscn_254](https://user-images.githubusercontent.com/6616005/30622456-c685de74-9d7f-11e7-93f1-e2df1aacf608.png)
